### PR TITLE
Remove unnecessary health check method

### DIFF
--- a/lib/rentlinx/client.rb
+++ b/lib/rentlinx/client.rb
@@ -11,10 +11,6 @@ module Rentlinx
       @api_token ||= authenticate(username, password)
     end
 
-    def self.health_check(username, password, api_url_prefix)
-      new(username, password, api_url_prefix)
-    end
-
     private
 
     def authenticate(username, password)

--- a/test/rentlinx/test_client.rb
+++ b/test/rentlinx/test_client.rb
@@ -5,10 +5,4 @@ require_relative '../helper'
 # Test the Rentlinx Client
 class TestRentlinxClient < MiniTest::Test
   include SetupMethods
-
-  def test_health_check
-    VCR.use_cassette('test_client') do
-      Rentlinx::Client.health_check(@username, @password, @site_url)
-    end
-  end
 end


### PR DESCRIPTION
Not gonna bump or redeploy the gem for this change because we can simply ignore the method until we have real changes that warrant redeployment.
