### PR TITLE
Fix link fetcher

### DIFF
--- a/lib/rentlinx/modules/link_client_methods.rb
+++ b/lib/rentlinx/modules/link_client_methods.rb
@@ -40,7 +40,7 @@ module Rentlinx
 
     def get_links_for_unit(unit)
       links = get_links_for_property_id(unit.propertyID)
-      links.select { |link| defined? link.unitID && link.unitID == unit.unitID }
+      links.select { |link| defined?(link.unitID) && link.unitID == unit.unitID }
     end
 
     def unpost_link(link)

--- a/lib/rentlinx/version.rb
+++ b/lib/rentlinx/version.rb
@@ -1,3 +1,3 @@
 module Rentlinx
-  VERSION = '0.7.4'
+  VERSION = '0.7.5'
 end

--- a/test/cassettes/test_link_client_methods-test_get_links_for_unit__only_gets_for_unit.yml
+++ b/test/cassettes/test_link_client_methods-test_get_links_for_unit__only_gets_for_unit.yml
@@ -1,0 +1,316 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost/authentication/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"<USERNAME>","password":"<PASSWORD>"}'
+    headers:
+      User-Agent:
+      - Rentlinx Ruby Client 0.7.3
+      Accept:
+      - "*/*"
+      Date:
+      - Mon, 10 Aug 2015 23:36:30 GMT
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 10 Aug 2015 23:36:23 GMT
+      Content-Length:
+      - '54'
+    body:
+      encoding: UTF-8
+      string: '{"AccessToken":"F49B4B03-BBB1-4DF3-923A-038C730A7E03"}'
+    http_version: 
+  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+- request:
+    method: put
+    uri: http://localhost/units/test_get_links_for_unit__only_gets_for_unit
+    body:
+      encoding: UTF-8
+      string: '{"unitID":"test_get_links_for_unit__only_gets_for_unit","propertyID":"test_post_link_property","name":"My
+        new unit","description":"Fabulous unit on the ocean side","rent":"1600","maxRent":"","deposit":"3200","maxDeposit":"","squareFeet":"","maxSquareFeet":"","bedrooms":"3","fullBaths":"2","halfBaths":"","isMobilityAccessible":"","isVisionAccessible":"","isHearingAccessible":"","rentIsBasedOnIncome":"","isOpenToLease":true,"dateAvailable":"06/15/2015","dateLeasedThrough":"","numUnits":"","numAvailable":""}'
+    headers:
+      User-Agent:
+      - Rentlinx Ruby Client 0.7.3
+      Accept:
+      - "*/*"
+      Date:
+      - Mon, 10 Aug 2015 23:36:30 GMT
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 10 Aug 2015 23:36:23 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"unit","unitID":"test_get_links_for_unit__only_gets_for_unit","propertyID":"test_post_link_property","isOpenToLease":true,"name":"My
+        new unit","description":"Fabulous unit on the ocean side","rent":1600.0,"maxRent":1600.0,"deposit":3200.0,"maxDeposit":3200.0,"squareFeet":null,"maxSquareFeet":null,"bedrooms":3,"fullBaths":2,"halfBaths":null,"isMobilityAccessible":null,"isVisionAccessible":null,"isHearingAccessible":null,"rentIsBasedOnIncome":null,"dateAvailable":"2015-06-15T00:00:00","dateLeasedThrough":null,"numUnits":null,"numAvailable":null}}'
+    http_version: 
+  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+- request:
+    method: put
+    uri: http://localhost/units/test_get_links_for_unit__only_gets_for_unit
+    body:
+      encoding: UTF-8
+      string: '{"unitID":"test_get_links_for_unit__only_gets_for_unit","propertyID":"test_post_link_property","name":"My
+        new unit","description":"Fabulous unit on the ocean side","rent":"1600","maxRent":"","deposit":"3200","maxDeposit":"","squareFeet":"","maxSquareFeet":"","bedrooms":"3","fullBaths":"2","halfBaths":"","isMobilityAccessible":"","isVisionAccessible":"","isHearingAccessible":"","rentIsBasedOnIncome":"","isOpenToLease":true,"dateAvailable":"06/15/2015","dateLeasedThrough":"","numUnits":"","numAvailable":""}'
+    headers:
+      User-Agent:
+      - Rentlinx Ruby Client 0.7.3
+      Accept:
+      - "*/*"
+      Date:
+      - Mon, 10 Aug 2015 23:36:30 GMT
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 10 Aug 2015 23:36:23 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"unit","unitID":"test_get_links_for_unit__only_gets_for_unit","propertyID":"test_post_link_property","isOpenToLease":true,"name":"My
+        new unit","description":"Fabulous unit on the ocean side","rent":1600.0,"maxRent":1600.0,"deposit":3200.0,"maxDeposit":3200.0,"squareFeet":null,"maxSquareFeet":null,"bedrooms":3,"fullBaths":2,"halfBaths":null,"isMobilityAccessible":null,"isVisionAccessible":null,"isHearingAccessible":null,"rentIsBasedOnIncome":null,"dateAvailable":"2015-06-15T00:00:00","dateLeasedThrough":null,"numUnits":null,"numAvailable":null}}'
+    http_version: 
+  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+- request:
+    method: put
+    uri: http://localhost/units/test_get_links_for_unit__only_gets_for_unit/links
+    body:
+      encoding: UTF-8
+      string: '[{"url":"http://youtube.com/","title":"Only You Can Prevent Wildfires!"}]'
+    headers:
+      User-Agent:
+      - Rentlinx Ruby Client 0.7.3
+      Accept:
+      - "*/*"
+      Date:
+      - Mon, 10 Aug 2015 23:36:30 GMT
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 10 Aug 2015 23:36:23 GMT
+      Content-Length:
+      - '190'
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"type":"link","title":"Only You Can Prevent Wildfires!","url":"http://youtube.com/","propertyID":"test_post_link_property","unitID":"test_get_links_for_unit__only_gets_for_unit"}]}'
+    http_version: 
+  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+- request:
+    method: put
+    uri: http://localhost/units/test_get_links_for_unit__only_gets_for_unit_2
+    body:
+      encoding: UTF-8
+      string: '{"unitID":"test_get_links_for_unit__only_gets_for_unit_2","propertyID":"test_post_link_property","name":"My
+        new unit","description":"Fabulous unit on the ocean side","rent":"1600","maxRent":"","deposit":"3200","maxDeposit":"","squareFeet":"","maxSquareFeet":"","bedrooms":"3","fullBaths":"2","halfBaths":"","isMobilityAccessible":"","isVisionAccessible":"","isHearingAccessible":"","rentIsBasedOnIncome":"","isOpenToLease":true,"dateAvailable":"06/15/2015","dateLeasedThrough":"","numUnits":"","numAvailable":""}'
+    headers:
+      User-Agent:
+      - Rentlinx Ruby Client 0.7.3
+      Accept:
+      - "*/*"
+      Date:
+      - Mon, 10 Aug 2015 23:36:30 GMT
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 10 Aug 2015 23:36:23 GMT
+      Content-Length:
+      - '568'
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"unit","unitID":"test_get_links_for_unit__only_gets_for_unit_2","propertyID":"test_post_link_property","isOpenToLease":true,"name":"My
+        new unit","description":"Fabulous unit on the ocean side","rent":1600.0,"maxRent":1600.0,"deposit":3200.0,"maxDeposit":3200.0,"squareFeet":null,"maxSquareFeet":null,"bedrooms":3,"fullBaths":2,"halfBaths":null,"isMobilityAccessible":null,"isVisionAccessible":null,"isHearingAccessible":null,"rentIsBasedOnIncome":null,"dateAvailable":"2015-06-15T00:00:00","dateLeasedThrough":null,"numUnits":null,"numAvailable":null}}'
+    http_version: 
+  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+- request:
+    method: put
+    uri: http://localhost/units/test_get_links_for_unit__only_gets_for_unit_2/links
+    body:
+      encoding: UTF-8
+      string: '[{"url":"http://ec2-52-27-51-241.us-west-2.compute.amazonaws.com/","title":"Test
+        Link"}]'
+    headers:
+      User-Agent:
+      - Rentlinx Ruby Client 0.7.3
+      Accept:
+      - "*/*"
+      Date:
+      - Mon, 10 Aug 2015 23:36:30 GMT
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 10 Aug 2015 23:36:23 GMT
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"type":"link","title":"Test Link","url":"http://ec2-52-27-51-241.us-west-2.compute.amazonaws.com/","propertyID":"test_post_link_property","unitID":"test_get_links_for_unit__only_gets_for_unit_2"}]}'
+    http_version: 
+  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+- request:
+    method: get
+    uri: http://localhost/properties/test_post_link_property/links
+    body:
+      encoding: UTF-8
+      string: 'null'
+    headers:
+      User-Agent:
+      - Rentlinx Ruby Client 0.7.3
+      Accept:
+      - "*/*"
+      Date:
+      - Mon, 10 Aug 2015 23:36:30 GMT
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 10 Aug 2015 23:36:23 GMT
+      Content-Length:
+      - '1062'
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"type":"link","title":"Only You Can Prevent Wildfires!","url":"http://youtube.com/","propertyID":"test_post_link_property","unitID":"test_post_link_unit"},{"type":"link","title":"Test
+        Link","url":"http://ec2-52-27-51-241.us-west-2.compute.amazonaws.com/","propertyID":"test_post_link_property","unitID":"test_post_link_unit_2"},{"type":"link","title":"Only
+        You Can Prevent Wildfires!","url":"http://youtube.com/","propertyID":"test_post_link_property","unitID":"test_post_link_unit_dsfsdfa"},{"type":"link","title":"Only
+        You Can Prevent Wildfires!","url":"http://youtube.com/","propertyID":"test_post_link_property","unitID":"test_get_links_for_unit__only_gets_for_unit"},{"type":"link","title":"Test
+        Link","url":"http://ec2-52-27-51-241.us-west-2.compute.amazonaws.com/","propertyID":"test_post_link_property","unitID":"test_get_links_for_unit__only_gets_for_unit_2"},{"type":"link","title":"Only
+        You Can Prevent Wildfires!","url":"http://youtube.com/","propertyID":"test_post_link_property","unitID":"test_get_links_for_unit__only_gets_for_unit_1"}]}'
+    http_version: 
+  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+recorded_with: VCR 2.9.3

--- a/test/cassettes/test_link_client_methods-test_get_links_for_unit__only_gets_for_unit.yml
+++ b/test/cassettes/test_link_client_methods-test_get_links_for_unit__only_gets_for_unit.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Mon, 10 Aug 2015 23:36:30 GMT
+      - Mon, 10 Aug 2015 23:46:16 GMT
       Content-Type:
       - application/json
   response:
@@ -35,14 +35,14 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Mon, 10 Aug 2015 23:36:23 GMT
+      - Mon, 10 Aug 2015 23:46:09 GMT
       Content-Length:
       - '54'
     body:
       encoding: UTF-8
       string: '{"AccessToken":"F49B4B03-BBB1-4DF3-923A-038C730A7E03"}'
     http_version: 
-  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+  recorded_at: Mon, 10 Aug 2015 23:46:16 GMT
 - request:
     method: put
     uri: http://localhost/units/test_get_links_for_unit__only_gets_for_unit
@@ -56,7 +56,7 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Mon, 10 Aug 2015 23:36:30 GMT
+      - Mon, 10 Aug 2015 23:46:16 GMT
       Content-Type:
       - application/json
   response:
@@ -79,7 +79,7 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Mon, 10 Aug 2015 23:36:23 GMT
+      - Mon, 10 Aug 2015 23:46:09 GMT
       Content-Length:
       - '566'
     body:
@@ -87,7 +87,7 @@ http_interactions:
       string: '{"data":{"type":"unit","unitID":"test_get_links_for_unit__only_gets_for_unit","propertyID":"test_post_link_property","isOpenToLease":true,"name":"My
         new unit","description":"Fabulous unit on the ocean side","rent":1600.0,"maxRent":1600.0,"deposit":3200.0,"maxDeposit":3200.0,"squareFeet":null,"maxSquareFeet":null,"bedrooms":3,"fullBaths":2,"halfBaths":null,"isMobilityAccessible":null,"isVisionAccessible":null,"isHearingAccessible":null,"rentIsBasedOnIncome":null,"dateAvailable":"2015-06-15T00:00:00","dateLeasedThrough":null,"numUnits":null,"numAvailable":null}}'
     http_version: 
-  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+  recorded_at: Mon, 10 Aug 2015 23:46:16 GMT
 - request:
     method: put
     uri: http://localhost/units/test_get_links_for_unit__only_gets_for_unit
@@ -101,7 +101,7 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Mon, 10 Aug 2015 23:36:30 GMT
+      - Mon, 10 Aug 2015 23:46:16 GMT
       Content-Type:
       - application/json
   response:
@@ -124,7 +124,7 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Mon, 10 Aug 2015 23:36:23 GMT
+      - Mon, 10 Aug 2015 23:46:09 GMT
       Content-Length:
       - '566'
     body:
@@ -132,7 +132,7 @@ http_interactions:
       string: '{"data":{"type":"unit","unitID":"test_get_links_for_unit__only_gets_for_unit","propertyID":"test_post_link_property","isOpenToLease":true,"name":"My
         new unit","description":"Fabulous unit on the ocean side","rent":1600.0,"maxRent":1600.0,"deposit":3200.0,"maxDeposit":3200.0,"squareFeet":null,"maxSquareFeet":null,"bedrooms":3,"fullBaths":2,"halfBaths":null,"isMobilityAccessible":null,"isVisionAccessible":null,"isHearingAccessible":null,"rentIsBasedOnIncome":null,"dateAvailable":"2015-06-15T00:00:00","dateLeasedThrough":null,"numUnits":null,"numAvailable":null}}'
     http_version: 
-  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+  recorded_at: Mon, 10 Aug 2015 23:46:16 GMT
 - request:
     method: put
     uri: http://localhost/units/test_get_links_for_unit__only_gets_for_unit/links
@@ -145,7 +145,7 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Mon, 10 Aug 2015 23:36:30 GMT
+      - Mon, 10 Aug 2015 23:46:16 GMT
       Content-Type:
       - application/json
   response:
@@ -168,14 +168,14 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Mon, 10 Aug 2015 23:36:23 GMT
+      - Mon, 10 Aug 2015 23:46:09 GMT
       Content-Length:
       - '190'
     body:
       encoding: UTF-8
       string: '{"data":[{"type":"link","title":"Only You Can Prevent Wildfires!","url":"http://youtube.com/","propertyID":"test_post_link_property","unitID":"test_get_links_for_unit__only_gets_for_unit"}]}'
     http_version: 
-  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+  recorded_at: Mon, 10 Aug 2015 23:46:16 GMT
 - request:
     method: put
     uri: http://localhost/units/test_get_links_for_unit__only_gets_for_unit_2
@@ -189,7 +189,7 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Mon, 10 Aug 2015 23:36:30 GMT
+      - Mon, 10 Aug 2015 23:46:16 GMT
       Content-Type:
       - application/json
   response:
@@ -212,7 +212,7 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Mon, 10 Aug 2015 23:36:23 GMT
+      - Mon, 10 Aug 2015 23:46:09 GMT
       Content-Length:
       - '568'
     body:
@@ -220,7 +220,7 @@ http_interactions:
       string: '{"data":{"type":"unit","unitID":"test_get_links_for_unit__only_gets_for_unit_2","propertyID":"test_post_link_property","isOpenToLease":true,"name":"My
         new unit","description":"Fabulous unit on the ocean side","rent":1600.0,"maxRent":1600.0,"deposit":3200.0,"maxDeposit":3200.0,"squareFeet":null,"maxSquareFeet":null,"bedrooms":3,"fullBaths":2,"halfBaths":null,"isMobilityAccessible":null,"isVisionAccessible":null,"isHearingAccessible":null,"rentIsBasedOnIncome":null,"dateAvailable":"2015-06-15T00:00:00","dateLeasedThrough":null,"numUnits":null,"numAvailable":null}}'
     http_version: 
-  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+  recorded_at: Mon, 10 Aug 2015 23:46:16 GMT
 - request:
     method: put
     uri: http://localhost/units/test_get_links_for_unit__only_gets_for_unit_2/links
@@ -234,7 +234,7 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Mon, 10 Aug 2015 23:36:30 GMT
+      - Mon, 10 Aug 2015 23:46:16 GMT
       Content-Type:
       - application/json
   response:
@@ -257,14 +257,14 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Mon, 10 Aug 2015 23:36:23 GMT
+      - Mon, 10 Aug 2015 23:46:09 GMT
       Content-Length:
       - '207'
     body:
       encoding: UTF-8
       string: '{"data":[{"type":"link","title":"Test Link","url":"http://ec2-52-27-51-241.us-west-2.compute.amazonaws.com/","propertyID":"test_post_link_property","unitID":"test_get_links_for_unit__only_gets_for_unit_2"}]}'
     http_version: 
-  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+  recorded_at: Mon, 10 Aug 2015 23:46:16 GMT
 - request:
     method: get
     uri: http://localhost/properties/test_post_link_property/links
@@ -277,7 +277,7 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Mon, 10 Aug 2015 23:36:30 GMT
+      - Mon, 10 Aug 2015 23:46:16 GMT
       Content-Type:
       - application/json
   response:
@@ -300,17 +300,65 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Mon, 10 Aug 2015 23:36:23 GMT
+      - Mon, 10 Aug 2015 23:46:09 GMT
       Content-Length:
-      - '1062'
+      - '1064'
     body:
       encoding: UTF-8
-      string: '{"data":[{"type":"link","title":"Only You Can Prevent Wildfires!","url":"http://youtube.com/","propertyID":"test_post_link_property","unitID":"test_post_link_unit"},{"type":"link","title":"Test
+      string: '{"data":[{"type":"link","title":"D@pper Duck & Gilly the Goose","url":"http://www.<USERNAME>.com","propertyID":"test_post_link_property","unitID":"test_post_link_unit"},{"type":"link","title":"Test
         Link","url":"http://ec2-52-27-51-241.us-west-2.compute.amazonaws.com/","propertyID":"test_post_link_property","unitID":"test_post_link_unit_2"},{"type":"link","title":"Only
         You Can Prevent Wildfires!","url":"http://youtube.com/","propertyID":"test_post_link_property","unitID":"test_post_link_unit_dsfsdfa"},{"type":"link","title":"Only
         You Can Prevent Wildfires!","url":"http://youtube.com/","propertyID":"test_post_link_property","unitID":"test_get_links_for_unit__only_gets_for_unit"},{"type":"link","title":"Test
         Link","url":"http://ec2-52-27-51-241.us-west-2.compute.amazonaws.com/","propertyID":"test_post_link_property","unitID":"test_get_links_for_unit__only_gets_for_unit_2"},{"type":"link","title":"Only
         You Can Prevent Wildfires!","url":"http://youtube.com/","propertyID":"test_post_link_property","unitID":"test_get_links_for_unit__only_gets_for_unit_1"}]}'
     http_version: 
-  recorded_at: Mon, 10 Aug 2015 23:36:30 GMT
+  recorded_at: Mon, 10 Aug 2015 23:46:16 GMT
+- request:
+    method: get
+    uri: http://localhost/properties/test_post_link_property/links
+    body:
+      encoding: UTF-8
+      string: 'null'
+    headers:
+      User-Agent:
+      - Rentlinx Ruby Client 0.7.3
+      Accept:
+      - "*/*"
+      Date:
+      - Mon, 10 Aug 2015 23:46:16 GMT
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 10 Aug 2015 23:46:09 GMT
+      Content-Length:
+      - '1064'
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"type":"link","title":"D@pper Duck & Gilly the Goose","url":"http://www.<USERNAME>.com","propertyID":"test_post_link_property","unitID":"test_post_link_unit"},{"type":"link","title":"Test
+        Link","url":"http://ec2-52-27-51-241.us-west-2.compute.amazonaws.com/","propertyID":"test_post_link_property","unitID":"test_post_link_unit_2"},{"type":"link","title":"Only
+        You Can Prevent Wildfires!","url":"http://youtube.com/","propertyID":"test_post_link_property","unitID":"test_post_link_unit_dsfsdfa"},{"type":"link","title":"Only
+        You Can Prevent Wildfires!","url":"http://youtube.com/","propertyID":"test_post_link_property","unitID":"test_get_links_for_unit__only_gets_for_unit"},{"type":"link","title":"Test
+        Link","url":"http://ec2-52-27-51-241.us-west-2.compute.amazonaws.com/","propertyID":"test_post_link_property","unitID":"test_get_links_for_unit__only_gets_for_unit_2"},{"type":"link","title":"Only
+        You Can Prevent Wildfires!","url":"http://youtube.com/","propertyID":"test_post_link_property","unitID":"test_get_links_for_unit__only_gets_for_unit_1"}]}'
+    http_version: 
+  recorded_at: Mon, 10 Aug 2015 23:46:16 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/test_link_client_methods-test_post_links__to_different_properties_raises_error.yml
+++ b/test/cassettes/test_link_client_methods-test_post_links__to_different_properties_raises_error.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://rentlinxdev.com/api/v2/authentication/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"appfolio","password":"test12"}'
+    headers:
+      User-Agent:
+      - Rentlinx Ruby Client 0.7.3
+      Accept:
+      - "*/*"
+      Date:
+      - Mon, 10 Aug 2015 23:07:38 GMT
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 10 Aug 2015 23:07:32 GMT
+      Content-Length:
+      - '54'
+    body:
+      encoding: UTF-8
+      string: '{"AccessToken":"F49B4B03-BBB1-4DF3-923A-038C730A7E03"}'
+    http_version: 
+  recorded_at: Mon, 10 Aug 2015 23:07:38 GMT
+recorded_with: VCR 2.9.3

--- a/test/cassettes/test_photo_client_methods-test_post_photos__invalid_photo_raises_invalid_object.yml
+++ b/test/cassettes/test_photo_client_methods-test_post_photos__invalid_photo_raises_invalid_object.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost/authentication/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"<USERNAME>","password":"<PASSWORD>"}'
+    headers:
+      User-Agent:
+      - Rentlinx Ruby Client 0.7.3
+      Accept:
+      - "*/*"
+      Date:
+      - Mon, 10 Aug 2015 23:27:11 GMT
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 10 Aug 2015 23:27:07 GMT
+      Content-Length:
+      - '54'
+    body:
+      encoding: UTF-8
+      string: '{"AccessToken":"F49B4B03-BBB1-4DF3-923A-038C730A7E03"}'
+    http_version: 
+  recorded_at: Mon, 10 Aug 2015 23:27:14 GMT
+recorded_with: VCR 2.9.3

--- a/test/modules/test_link_client_methods.rb
+++ b/test/modules/test_link_client_methods.rb
@@ -88,12 +88,7 @@ class LinkClientMethodsTest < MiniTest::Test
 
       Rentlinx.client.post_links([@unit_link])
 
-      new_links = Rentlinx.client.get_links_for_unit(@unit)
-      assert_equal 1, new_links.size
-      assert_equal @unit_link.propertyID, new_links.first.propertyID
-      assert_equal @unit_link.unitID, new_links.first.unitID
-      assert_equal @unit_link.title, new_links.first.title
-      assert_equal @unit_link.url, new_links.first.url
+      assert_unit_links_equal @unit_link, Rentlinx.client.get_links_for_unit(@unit)
     end
   end
 
@@ -101,12 +96,7 @@ class LinkClientMethodsTest < MiniTest::Test
     use_vcr do
       links = Rentlinx.client.get_links_for_unit(@unit)
 
-      assert_equal 1, links.size
-      assert_equal links.first.class, Rentlinx::UnitLink
-      assert_equal @unit_link.propertyID, links.first.propertyID
-      assert_equal @unit_link.unitID, links.first.unitID
-      assert_equal @unit_link.title, links.first.title
-      assert_equal @unit_link.url, links.first.url
+      assert_unit_links_equal @unit_link, links
     end
   end
 
@@ -122,23 +112,10 @@ class LinkClientMethodsTest < MiniTest::Test
       # New unit on the same property
       unit2.unitID = 'test_get_links_for_unit__only_gets_for_unit_2'
       unit2.add_link(title: 'Test Link', url: 'http://ec2-52-27-51-241.us-west-2.compute.amazonaws.com/')
-
       unit2.post_with_links
 
-      links = Rentlinx.client.get_links_for_unit(@unit)
-
-      assert_equal 1, links.size
-      assert_equal links.first.class, Rentlinx::UnitLink
-      assert_equal @unit_link.propertyID, links.first.propertyID
-      assert_equal @unit_link.unitID, links.first.unitID
-      assert_equal @unit_link.title, links.first.title
-      assert_equal @unit_link.url, links.first.url
-
-      links = Rentlinx.client.get_links_for_unit(unit2)
-
-      assert_equal 1, links.size
-      assert_equal links.first.class, Rentlinx::UnitLink
-      assert_equal 'Test Link', links.first.title
+      assert_unit_links_equal @unit_link, Rentlinx.client.get_links_for_unit(@unit)
+      assert_unit_links_equal unit2.links.first, Rentlinx.client.get_links_for_unit(unit2)
     end
   end
 
@@ -203,6 +180,8 @@ class LinkClientMethodsTest < MiniTest::Test
     end
   end
 
+  private
+
   def setup
     super
 
@@ -215,5 +194,15 @@ class LinkClientMethodsTest < MiniTest::Test
 
     @prop_link = Rentlinx::PropertyLink.new(VALID_PROPERTY_LINK_ATTRS.merge(propertyID: @prop.propertyID))
     @unit_link = Rentlinx::UnitLink.new(VALID_UNIT_LINK_ATTRS.merge(propertyID: @prop.propertyID, unitID: @unit.unitID))
+  end
+
+  def assert_unit_links_equal(expected, given_arr)
+    assert_equal 1, given_arr.size
+    given = given_arr.first
+    assert_equal given.class, Rentlinx::UnitLink
+    assert_equal expected.propertyID, given.propertyID
+    assert_equal expected.unitID, given.unitID
+    assert_equal expected.title, given.title
+    assert_equal expected.url, given.url
   end
 end

--- a/test/modules/test_link_client_methods.rb
+++ b/test/modules/test_link_client_methods.rb
@@ -133,6 +133,12 @@ class LinkClientMethodsTest < MiniTest::Test
       assert_equal @unit_link.unitID, links.first.unitID
       assert_equal @unit_link.title, links.first.title
       assert_equal @unit_link.url, links.first.url
+
+      links = Rentlinx.client.get_links_for_unit(unit2)
+
+      assert_equal 1, links.size
+      assert_equal links.first.class, Rentlinx::UnitLink
+      assert_equal 'Test Link', links.first.title
     end
   end
 

--- a/test/modules/test_link_client_methods.rb
+++ b/test/modules/test_link_client_methods.rb
@@ -110,6 +110,32 @@ class LinkClientMethodsTest < MiniTest::Test
     end
   end
 
+  def test_get_links_for_unit__only_gets_for_unit
+    use_vcr do
+      unit2 = @unit.dup
+
+      @unit.unitID = 'test_get_links_for_unit__only_gets_for_unit'
+      @unit.post
+      @unit.links = [@unit_link]
+      @unit.post_with_links
+
+      # New unit on the same property
+      unit2.unitID = 'test_get_links_for_unit__only_gets_for_unit_2'
+      unit2.add_link(title: 'Test Link', url: 'http://ec2-52-27-51-241.us-west-2.compute.amazonaws.com/')
+
+      unit2.post_with_links
+
+      links = Rentlinx.client.get_links_for_unit(@unit)
+
+      assert_equal 1, links.size
+      assert_equal links.first.class, Rentlinx::UnitLink
+      assert_equal @unit_link.propertyID, links.first.propertyID
+      assert_equal @unit_link.unitID, links.first.unitID
+      assert_equal @unit_link.title, links.first.title
+      assert_equal @unit_link.url, links.first.url
+    end
+  end
+
   def test_post_link_title_gets_escaped
     use_vcr do
       links = Rentlinx.client.get_links_for_unit(@unit)


### PR DESCRIPTION
Turns out `&&` and `==` have higher precedence than a method with no parens, so the line was equivalent to `defined?(link.unitID && link.unitID == unit.unitID)` which always returns true which is wrong.
