### PR TITLE
ml - move gem 'logging’ dependency to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ group :test do
   gem 'rake'
   gem 'vcr'
   gem 'webmock'
-  gem 'logging'
   gem 'mocha'
 end
 

--- a/rentlinx.gemspec
+++ b/rentlinx.gemspec
@@ -13,4 +13,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'httpclient', '~> 2.6.0'
   s.add_runtime_dependency 'json', '~> 1.8'
   s.add_runtime_dependency 'phony', '~> 2.12'
+  s.add_runtime_dependency 'logging', '~> 2.0.0'
 end


### PR DESCRIPTION
Although mostly used for testing, it can be used in any environment
