### PR TITLE
ml - use BigDecimal instead of String for amounts

### DIFF
--- a/lib/rentlinx/validators/amount_validator.rb
+++ b/lib/rentlinx/validators/amount_validator.rb
@@ -6,8 +6,7 @@ module Rentlinx
     private
 
     def validate
-      @value.sub!(/^0+/, '') unless @value.nil?
-      return if @value.to_s =~ /[1-9]\d*(\.\d{1,2})?/
+      return if !@value.nil? && @value.is_a?(Numeric) && @value >= 0
       @error = "'#{@value}' is not a valid amount."
     end
   end

--- a/test/cassettes/test_company-test_company_from_id.yml
+++ b/test/cassettes/test_company-test_company_from_id.yml
@@ -83,7 +83,7 @@ http_interactions:
       - '529'
     body:
       encoding: UTF-8
-      string: '{"data":{"type":"company","companyID":"test-company-id","companyCapAmount":"1000.00"}}'
+      string: '{"data":{"type":"company","companyID":"test-company-id","companyCapAmount":0.1E4}}'
     http_version:
   recorded_at: Thu, 18 Jun 2015 17:47:21 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/test_property-test_property_patch_method.yml
+++ b/test/cassettes/test_property-test_property_patch_method.yml
@@ -93,7 +93,7 @@ http_interactions:
     uri: http://localhost/properties/test-property-id
     body:
       encoding: UTF-8
-      string: '{"propertyID":"test-property-id","premium":true,"capAmount":"100.00"}'
+      string: '{"propertyID":"test-property-id","premium":true,"capAmount":100.0}'
     headers:
       User-Agent:
       - Rentlinx Ruby Client 0.9.3

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -48,7 +48,7 @@ end
 
 VALID_COMPANY_ATTRS = {
   companyID: 'test-company-id',
-  companyCapAmount: '1000.00'
+  companyCapAmount: BigDecimal.new('1000.00')
 }
 
 VALID_PROPERTY_ATTRS = {

--- a/test/models/test_company.rb
+++ b/test/models/test_company.rb
@@ -24,7 +24,7 @@ class CompanyTest < MiniTest::Test
     use_vcr do
       prop = Rentlinx::Company.from_id('test-company-id')
 
-      assert prop.valid?
+      assert_empty prop.validate
       assert_equal 'test-company-id', prop.companyID
     end
   end

--- a/test/models/test_property.rb
+++ b/test/models/test_property.rb
@@ -98,7 +98,7 @@ class PropertyTest < MiniTest::Test
       h2 = {
         propertyID: 'test-property-id',
         premium: true,
-        capAmount: '100.00'
+        capAmount: BigDecimal.new('100.00')
       }
       prop2 = Rentlinx::Property.new(h2)
       prop2.patch
@@ -262,7 +262,7 @@ class PropertyTest < MiniTest::Test
   def test_add_photo
     prop = Rentlinx::Property.new(VALID_PROPERTY_ATTRS)
     prop.add_photo(url: 'http://asdf.com/wat.png', caption: 'this is a picture')
-    assert 1, prop.photos.size
+    assert_equal 1, prop.photos.size
     assert_equal 'this is a picture', prop.photos.first.caption
     assert_equal prop.propertyID, prop.photos.first.propertyID
   end
@@ -286,7 +286,7 @@ class PropertyTest < MiniTest::Test
     prop = Rentlinx::Property.new(VALID_PROPERTY_ATTRS)
     prop.add_amenity(name: '12 Months', details: 'We like long-term commitments')
 
-    assert 1, prop.amenities.size
+    assert_equal 1, prop.amenities.size
     assert_equal '12 Months', prop.amenities.first.name
     assert_equal 'We like long-term commitments', prop.amenities.first.details
     assert_equal prop.propertyID, prop.amenities.first.propertyID
@@ -311,7 +311,7 @@ class PropertyTest < MiniTest::Test
     prop = Rentlinx::Property.new(VALID_PROPERTY_ATTRS)
     prop.add_link(title: '12 Months', url: 'http://www.youtube.com/')
 
-    assert 1, prop.links.size
+    assert_equal 1, prop.links.size
     assert_equal '12 Months', prop.links.first.title
     assert_equal 'http://www.youtube.com/', prop.links.first.url
     assert_equal prop.propertyID, prop.links.first.propertyID

--- a/test/models/test_unit.rb
+++ b/test/models/test_unit.rb
@@ -118,7 +118,7 @@ class UnitTest < MiniTest::Test
   def test_add_photo
     unit = Rentlinx::Unit.new(VALID_UNIT_ATTRS)
     unit.add_photo(url: 'http://asdf.com/wat.png', caption: 'this is a picture')
-    assert 1, unit.photos.size
+    assert_equal 1, unit.photos.size
     assert_equal 'this is a picture', unit.photos.first.caption
     assert_equal unit.propertyID, unit.photos.first.propertyID
     assert_equal unit.unitID, unit.photos.first.unitID
@@ -143,7 +143,7 @@ class UnitTest < MiniTest::Test
     unit = Rentlinx::Unit.new(VALID_UNIT_ATTRS)
     unit.add_amenity(name: '12 Months', details: 'We like long-term commitments')
 
-    assert 1, unit.amenities.size
+    assert_equal 1, unit.amenities.size
     assert_equal '12 Months', unit.amenities.first.name
     assert_equal 'We like long-term commitments', unit.amenities.first.details
     assert_equal unit.propertyID, unit.amenities.first.propertyID
@@ -169,7 +169,7 @@ class UnitTest < MiniTest::Test
     unit = Rentlinx::Unit.new(VALID_UNIT_ATTRS)
     unit.add_link(title: '12 Months', url: 'http://www.youtube.com/')
 
-    assert 1, unit.links.size
+    assert_equal 1, unit.links.size
     assert_equal '12 Months', unit.links.first.title
     assert_equal 'http://www.youtube.com/', unit.links.first.url
     assert_equal unit.propertyID, unit.links.first.propertyID

--- a/test/validators/test_address_validator.rb
+++ b/test/validators/test_address_validator.rb
@@ -16,6 +16,6 @@ class AddressValidatorTest < MiniTest::Test
 
   def test_processed_value
     v = Rentlinx::AddressValidator.new('50 Castilian Dr.')
-    assert '50 Castilian Dr.', v.processed_value
+    assert_equal '50 Castilian Dr.', v.processed_value
   end
 end

--- a/test/validators/test_amount_validator.rb
+++ b/test/validators/test_amount_validator.rb
@@ -16,24 +16,9 @@ class AmountValidatorTest < MiniTest::Test
   end
 
   def test_validate__valid
-    v = Rentlinx::AmountValidator.new('050')
+    v = Rentlinx::AmountValidator.new(BigDecimal.new('05.2'))
     assert v.valid?
-    assert '50', v.processed_value
-
-    v = Rentlinx::AmountValidator.new('50')
-    assert v.valid?
-    assert '50', v.processed_value
-
-    v = Rentlinx::AmountValidator.new('50.0')
-    assert v.valid?
-    assert '50.0', v.processed_value
-
-    v = Rentlinx::AmountValidator.new('50.01')
-    assert v.valid?
-    assert '50.01', v.processed_value
-
-    v = Rentlinx::AmountValidator.new('100.00')
-    assert v.valid?
-    assert '100.00', v.processed_value
+    assert_equal BigDecimal, v.processed_value.class
+    assert_equal '0.52E1', v.processed_value.to_s
   end
 end

--- a/test/validators/test_city_validator.rb
+++ b/test/validators/test_city_validator.rb
@@ -16,6 +16,6 @@ class CityValidatorTest < MiniTest::Test
 
   def test_processed_value
     v = Rentlinx::CityValidator.new('Los Angeles')
-    assert 'Los Angeles', v.processed_value
+    assert_equal 'Los Angeles', v.processed_value
   end
 end

--- a/test/validators/test_zip_validator.rb
+++ b/test/validators/test_zip_validator.rb
@@ -22,9 +22,9 @@ class ZipValidatorTest < MiniTest::Test
 
   def test_processed_value
     v = Rentlinx::ZipValidator.new('93101')
-    assert '93101', v.processed_value
+    assert_equal '93101', v.processed_value
 
     v = Rentlinx::ZipValidator.new('93101-1234')
-    assert '93101-1234', v.processed_value
+    assert_equal '93101-1234', v.processed_value
   end
 end


### PR DESCRIPTION
Note: Rails as_json converts String, so don’t use that

Also change assert to assert_equal
Note: assert ignores the second arg :-(
