### PR TITLE
Lock in gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ group :test do
   gem 'coveralls'
   gem 'minitest'
   gem 'rake'
-  gem 'vcr'
-  gem 'webmock'
+  gem 'vcr', '2.9.3'
+  gem 'webmock', '1.22.6'
   gem 'mocha'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,5 @@ group :test do
 end
 
 group :development do
-  gem 'rubocop'
+  gem 'rubocop', '0.39.0'
 end

--- a/lib/rentlinx.rb
+++ b/lib/rentlinx.rb
@@ -31,8 +31,8 @@ module Rentlinx
     #     rentlinx.site_url 'https://rentlinx.com/api/v2'
     #     rentlinx.log_level :error
     #   end
-    def configure(&block)
-      block.call(self)
+    def configure
+      yield(self)
     end
 
     # Sets and retrieves the username used to log in to Rentlinx

--- a/lib/rentlinx/models/base.rb
+++ b/lib/rentlinx/models/base.rb
@@ -23,7 +23,7 @@ module Rentlinx
         send("#{at}=", attrs[at])
       end
       remaining_attrs = attrs.keys - attributes
-      raise UnexpectedAttributes, "Unexpected Attributes: #{remaining_attrs.join(', ')}" if remaining_attrs.compact.size > 0
+      raise UnexpectedAttributes, "Unexpected Attributes: #{remaining_attrs.join(', ')}" unless remaining_attrs.compact.empty?
     end
 
     # Provides a list of attributes supported by the class.
@@ -117,20 +117,22 @@ module Rentlinx
 
     private
 
-    def self.unpost(id)
-      Rentlinx.client.unpost(type, id)
-    end
+    class << self
+      def unpost(id)
+        Rentlinx.client.unpost(type, id)
+      end
 
-    def self.get_from_id(type, id)
-      Rentlinx.client.get(type.to_sym, id)
+      def get_from_id(type, id)
+        Rentlinx.client.get(type.to_sym, id)
+      end
+
+      def type
+        name.split('::').last.downcase.to_sym
+      end
     end
 
     def type
       self.class.type
-    end
-
-    def self.type
-      name.split('::').last.downcase.to_sym
     end
 
     def identity

--- a/lib/rentlinx/models/company.rb
+++ b/lib/rentlinx/models/company.rb
@@ -1,9 +1,9 @@
 module Rentlinx
   # An object that represents a Rentlinx company.
   class Company < Base
-    ATTRIBUTES = [:companyID, :companyCapAmount]
+    ATTRIBUTES = [:companyID, :companyCapAmount].freeze
 
-    REQUIRED_ATTRIBUTES = [:companyID]
+    REQUIRED_ATTRIBUTES = [:companyID].freeze
 
     attr_accessor(*ATTRIBUTES)
 

--- a/lib/rentlinx/models/lead.rb
+++ b/lib/rentlinx/models/lead.rb
@@ -1,8 +1,8 @@
 module Rentlinx
   # An object that represets Rentlinx Leads
   class Lead < Base
-    ATTRIBUTES = [:leadID, :refunded, :refund_reason]
-    REQUIRED_ATTRIBUTES = [:leadID, :refunded, :refund_reason]
+    ATTRIBUTES = [:leadID, :refunded, :refund_reason].freeze
+    REQUIRED_ATTRIBUTES = [:leadID, :refunded, :refund_reason].freeze
 
     attr_accessor(*ATTRIBUTES)
   end

--- a/lib/rentlinx/models/property.rb
+++ b/lib/rentlinx/models/property.rb
@@ -10,10 +10,10 @@ module Rentlinx
                   :website, :yearBuilt, :numUnits, :phoneNumber, :extension,
                   :faxNumber, :emailAddress, :acceptsHcv, :propertyType,
                   :activeURL, :companyName, :leadsURL,
-                  :premium, :capAmount]
+                  :premium, :capAmount].freeze
 
     REQUIRED_ATTRIBUTES = [:propertyID, :address, :city, :state, :zip,
-                           :phoneNumber, :emailAddress]
+                           :phoneNumber, :emailAddress].freeze
 
     attr_accessor(*ATTRIBUTES)
 

--- a/lib/rentlinx/models/property_amenity.rb
+++ b/lib/rentlinx/models/property_amenity.rb
@@ -1,9 +1,9 @@
 module Rentlinx
   # An amenity on a propery
   class PropertyAmenity < Base
-    ATTRIBUTES = [:details, :name, :propertyID]
+    ATTRIBUTES = [:details, :name, :propertyID].freeze
 
-    REQUIRED_ATTRIBUTES = [:name, :propertyID]
+    REQUIRED_ATTRIBUTES = [:name, :propertyID].freeze
 
     attr_accessor(*ATTRIBUTES)
 

--- a/lib/rentlinx/models/property_link.rb
+++ b/lib/rentlinx/models/property_link.rb
@@ -1,9 +1,9 @@
 module Rentlinx
   # A link on a property
   class PropertyLink < Base
-    ATTRIBUTES = [:propertyID, :title, :url]
+    ATTRIBUTES = [:propertyID, :title, :url].freeze
 
-    REQUIRED_ATTRIBUTES = [:propertyID, :title, :url]
+    REQUIRED_ATTRIBUTES = [:propertyID, :title, :url].freeze
 
     attr_accessor(*ATTRIBUTES)
 

--- a/lib/rentlinx/models/property_photo.rb
+++ b/lib/rentlinx/models/property_photo.rb
@@ -1,9 +1,9 @@
 module Rentlinx
   # A photo on a property
   class PropertyPhoto < Base
-    ATTRIBUTES = [:url, :caption, :position, :propertyID, :unitID]
+    ATTRIBUTES = [:url, :caption, :position, :propertyID, :unitID].freeze
 
-    REQUIRED_ATTRIBUTES = [:url, :propertyID]
+    REQUIRED_ATTRIBUTES = [:url, :propertyID].freeze
 
     attr_accessor(*ATTRIBUTES)
 

--- a/lib/rentlinx/models/unit.rb
+++ b/lib/rentlinx/models/unit.rb
@@ -10,9 +10,9 @@ module Rentlinx
                   :bedrooms, :fullBaths, :halfBaths, :isMobilityAccessible,
                   :isVisionAccessible, :isHearingAccessible, :rentIsBasedOnIncome,
                   :isOpenToLease, :dateAvailable, :dateLeasedThrough, :numUnits,
-                  :numAvailable]
+                  :numAvailable].freeze
 
-    REQUIRED_ATTRIBUTES = [:unitID]
+    REQUIRED_ATTRIBUTES = [:unitID].freeze
 
     attr_accessor(*ATTRIBUTES)
 

--- a/lib/rentlinx/modules/amenityable.rb
+++ b/lib/rentlinx/modules/amenityable.rb
@@ -17,7 +17,7 @@ module Rentlinx
     def post_amenities
       return if @amenities.nil?
 
-      if @amenities.length == 0
+      if @amenities.empty?
         Rentlinx.client.unpost_amenities_for(self)
       else
         Rentlinx.client.post_amenities(@amenities)
@@ -58,8 +58,8 @@ module Rentlinx
     #   {Rentlinx::PropertyAmenity}
     # @return the updated list of amenities on the object
     def add_amenity(options)
-      options.merge!(propertyID: propertyID)
-      options.merge!(unitID: unitID) if defined? unitID
+      options[:propertyID] = propertyID
+      options[:unitID] = unitID if defined? unitID
       @amenities ||= []
       @amenities << amenity_class.new(options)
     end

--- a/lib/rentlinx/modules/linkable.rb
+++ b/lib/rentlinx/modules/linkable.rb
@@ -17,7 +17,7 @@ module Rentlinx
     def post_links
       return if @links.nil?
 
-      if @links.length == 0
+      if @links.empty?
         Rentlinx.client.unpost_links_for(self)
       else
         Rentlinx.client.post_links(@links)
@@ -45,8 +45,8 @@ module Rentlinx
     end
 
     def add_link(options)
-      options.merge!(propertyID: propertyID)
-      options.merge!(unitID: unitID) if defined? unitID
+      options[:propertyID] = propertyID
+      options[:unitID] = unitID if defined? unitID
       @links ||= []
       @links << link_class.new(options)
     end

--- a/lib/rentlinx/modules/photoable.rb
+++ b/lib/rentlinx/modules/photoable.rb
@@ -12,7 +12,7 @@ module Rentlinx
     def post_photos
       return if @photos.nil?
 
-      if @photos.length == 0
+      if @photos.empty?
         Rentlinx.client.unpost_photos_for(self)
       else
         Rentlinx.client.post_photos(@photos)
@@ -32,8 +32,8 @@ module Rentlinx
     end
 
     def add_photo(options)
-      options.merge!(propertyID: propertyID)
-      options.merge!(unitID: unitID) if defined? unitID
+      options[:propertyID] = propertyID
+      options[:unitID] = unitID if defined? unitID
       @photos ||= []
       @photos << photo_class.new(options)
     end

--- a/lib/rentlinx/validators/attribute_processor_service.rb
+++ b/lib/rentlinx/validators/attribute_processor_service.rb
@@ -56,7 +56,7 @@ module Rentlinx
     #
     # @return [Boolean] true if valid, false if not
     def valid?
-      @errors.size == 0
+      @errors.empty?
     end
   end
 end

--- a/lib/rentlinx/validators/state_validator.rb
+++ b/lib/rentlinx/validators/state_validator.rb
@@ -5,7 +5,7 @@ module Rentlinx
   class StateValidator < BaseValidator
     STATES = %w(AK AL AR AS AZ CA CO CT DC DE FL GA GU HI IA ID IL IN KS KY LA
                 MA MD ME MI MN MO MP MS MT NC ND NE NH NJ NM NV NY OH OK OR PA
-                PR RI SC SD TN TX UT VA VI VT WA WI WV WY)
+                PR RI SC SD TN TX UT VA VI VT WA WI WV WY).freeze
 
     private
 

--- a/lib/rentlinx/version.rb
+++ b/lib/rentlinx/version.rb
@@ -1,5 +1,5 @@
 # This is the main rentlinx module. All Rentlinx objects
 # and methods are namespaced under this module.
 module Rentlinx
-  VERSION = '0.9.6'
+  VERSION = '0.9.6'.freeze
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -49,7 +49,7 @@ end
 VALID_COMPANY_ATTRS = {
   companyID: 'test-company-id',
   companyCapAmount: BigDecimal.new('1000.00')
-}
+}.freeze
 
 VALID_PROPERTY_ATTRS = {
   propertyID: 'test-property-id',
@@ -62,7 +62,7 @@ VALID_PROPERTY_ATTRS = {
   emailAddress: 'support@appfolio.com',
   companyID: 'test-company-id',
   companyName: 'test company'
-}
+}.freeze
 
 VALID_UNIT_ATTRS = {
   propertyID: 'test-property-id',
@@ -87,7 +87,7 @@ VALID_UNIT_ATTRS = {
   dateLeasedThrough: '',
   numUnits: '',
   numAvailable: ''
-}
+}.freeze
 
 VALID_PROPERTY_PHOTO_ATTRS = {
   propertyID: 'test-property-id',
@@ -95,7 +95,7 @@ VALID_PROPERTY_PHOTO_ATTRS = {
   url: 'http://alexstandke.com/img/me.png',
   caption: 'This is a photo of my house',
   # position: 1,
-}
+}.freeze
 
 VALID_UNIT_PHOTO_ATTRS = {
   propertyID: 'test-property-id',
@@ -103,30 +103,30 @@ VALID_UNIT_PHOTO_ATTRS = {
   url: 'http://alexstandke.com/img/contact-banner.jpg',
   caption: 'This is a photo of my unit',
   # position: 1,
-}
+}.freeze
 
 VALID_PROPERTY_AMENITY_ATTRS = {
   propertyID: 'test-property-amenity-id',
   name: 'Garbage Disposal',
   details: 'Some details about your garbage'
-}
+}.freeze
 
 VALID_UNIT_AMENITY_ATTRS = {
   propertyID: 'test-property-amenity-id',
   unitID: 'test-unit-amenity-id',
   name: 'No Dogs Allowed',
   details: 'We do not like dogs'
-}
+}.freeze
 
 VALID_PROPERTY_LINK_ATTRS = {
   propertyID: 'test-property-link-id',
   url: 'http://google.com/',
   title: 'Ring ding'
-}
+}.freeze
 
 VALID_UNIT_LINK_ATTRS = {
   propertyID: 'test-property-link-id',
   unitID: 'sebastiens forest hut',
   url: 'http://youtube.com/',
   title: 'Only You Can Prevent Wildfires!'
-}
+}.freeze


### PR DESCRIPTION
Webmock made a breaking change with 2.0.0 that VCR doesn't yet handle, so CI and local tests were failing because http requests were not actually mocked out. So these gems were locked in at the versions the rentlinx_gem requires.

Also, rubocop updated their style guide, invalidating a lot of our past style, so it was locked at the newest version and offenses fixed.

Since all of these gems are for development only, locking them down does not interfere with Property or any other apps they might be included in.
