### PR TITLE
Relax httpclient version requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ matrix:
     - rvm: jruby-head
     - rvm: ruby-head
 rvm:
-  - jruby-19mode
   - jruby-head
-  - 1.9.3
   - 2.0.0
   - 2.1.7
   - 2.2.3

--- a/rentlinx.gemspec
+++ b/rentlinx.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary = 'API Wrapper for the Rentlinx API'
   s.version = Rentlinx::VERSION
 
-  s.add_runtime_dependency 'httpclient', '~> 2.6.0'
+  s.add_runtime_dependency 'httpclient', '~> 2.6'
   s.add_runtime_dependency 'json', '~> 1.8'
   s.add_runtime_dependency 'logging', '~> 2.0.0'
 end


### PR DESCRIPTION
The current httpclient version requirement is `~> 2.6.0`, which is causing conflicts with other libraries that require newer versions.  `2.7.0` was released back in 2015 so we are stuck on an old version.

This PR relaxes the requirement to `~> 2.6` which means anything within the `2.x` range will be allowed.  The httpclient library follows semver so this shouldn't introduce any issues.