### PR TITLE
Add Codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# They will be requested for
+# review when someone opens a pull request.
+*       @scuendet

--- a/stewards.yml
+++ b/stewards.yml
@@ -1,2 +1,0 @@
-stewards:
- - scuendet


### PR DESCRIPTION
As Appfolio devs, we use Github codeowners rather than Ladle App for stewardship, so that we aren't unnecessarily using in house tools and so that we get suggested reviewers for our PRs.