### PR TITLE
js - bump json gem to v2.3.0

### DIFF
--- a/rentlinx.gemspec
+++ b/rentlinx.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |s|
   s.version = Rentlinx::VERSION
 
   s.add_runtime_dependency 'httpclient', '~> 2.6'
-  s.add_runtime_dependency 'json', '~> 1.8'
+  s.add_runtime_dependency 'json', '~> 2.3.0'
   s.add_runtime_dependency 'logging', '~> 2.0.0'
 end


### PR DESCRIPTION
to fix the sourceclear issue:
https://appfolio.sourceclear.io/workspaces/WzzFK1A/issues/vulnerabilities/30679999