### PR TITLE
Relax json requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,7 @@ end
 group :development do
   gem 'rubocop', '0.39.0'
 end
+
+group :development, :test do
+  gem 'debug'
+end

--- a/lib/rentlinx/modules/amenity_client_methods.rb
+++ b/lib/rentlinx/modules/amenity_client_methods.rb
@@ -109,11 +109,11 @@ module Rentlinx
     end
 
     def unpost_property_amenity(id, name)
-      request('DELETE', URI.encode("properties/#{id}/amenities/#{name}"))
+      request('DELETE', "properties/#{ERB::Util.url_encode (id)}/amenities/#{ERB::Util.url_encode (name)}")
     end
 
     def unpost_unit_amenity(id, name)
-      request('DELETE', URI.encode("units/#{id}/amenities/#{name}"))
+      request('DELETE', "units/#{ERB::Util.url_encode (id)}/amenities/#{ERB::Util.url_encode (name)}")
     end
   end
 end

--- a/lib/rentlinx/modules/link_client_methods.rb
+++ b/lib/rentlinx/modules/link_client_methods.rb
@@ -108,11 +108,11 @@ module Rentlinx
     end
 
     def unpost_property_link(id, url)
-      request('DELETE', URI.encode("properties/#{id}/links/"), url: url)
+      request('DELETE', "properties/#{ERB::Util.url_encode (id)}/links/", url: url)
     end
 
     def unpost_unit_link(id, url)
-      request('DELETE', URI.encode("units/#{id}/links/"), url: url)
+      request('DELETE', "units/#{ERB::Util.url_encode (id)}/links/", url: url)
     end
   end
 end

--- a/lib/rentlinx/version.rb
+++ b/lib/rentlinx/version.rb
@@ -1,5 +1,5 @@
 # This is the main rentlinx module. All Rentlinx objects
 # and methods are namespaced under this module.
 module Rentlinx
-  VERSION = '0.13.0'.freeze
+  VERSION = '0.14.0'.freeze
 end

--- a/rentlinx.gemspec
+++ b/rentlinx.gemspec
@@ -13,4 +13,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'httpclient', '~> 2.6'
   s.add_runtime_dependency 'json', '~> 2.3.0'
   s.add_runtime_dependency 'logging', '~> 2.0.0'
+
+  s.required_ruby_version = '>= 3'
 end

--- a/rentlinx.gemspec
+++ b/rentlinx.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'httpclient', '~> 2.6'
   s.add_runtime_dependency 'json', '~> 2.3.0'
-  s.add_runtime_dependency 'logging', '~> 2.0.0'
+  s.add_runtime_dependency 'logging', '~> 2.3'
 
   s.required_ruby_version = '>= 3'
 end

--- a/rentlinx.gemspec
+++ b/rentlinx.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.version = Rentlinx::VERSION
 
   s.add_runtime_dependency 'httpclient', '~> 2.6'
-  s.add_runtime_dependency 'json', '~> 2.3.0'
+  s.add_runtime_dependency 'json', '~> 2.3'
   s.add_runtime_dependency 'logging', '~> 2.3'
 
   s.required_ruby_version = '>= 3'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -48,7 +48,7 @@ end
 
 VALID_COMPANY_ATTRS = {
   companyID: 'test-company-id',
-  companyCapAmount: BigDecimal.new('1000.00')
+  companyCapAmount: BigDecimal('1000.00')
 }.freeze
 
 VALID_PROPERTY_ATTRS = {

--- a/test/models/test_base.rb
+++ b/test/models/test_base.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class BaseTest < MiniTest::Test
+class BaseTest < Minitest::Test
   def test_new
     assert_raises(NameError) do
       Rentlinx::Base.new(fakeParam: '1234')

--- a/test/models/test_company.rb
+++ b/test/models/test_company.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class CompanyTest < MiniTest::Test
+class CompanyTest < Minitest::Test
   include SetupMethods
 
   def test_new

--- a/test/models/test_lead.rb
+++ b/test/models/test_lead.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class LeadTest < MiniTest::Test
+class LeadTest < Minitest::Test
   include SetupMethods
 
   def test_post

--- a/test/models/test_property.rb
+++ b/test/models/test_property.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class PropertyTest < MiniTest::Test
+class PropertyTest < Minitest::Test
   include SetupMethods
 
   def test_new
@@ -98,7 +98,7 @@ class PropertyTest < MiniTest::Test
       h2 = {
         propertyID: 'test-property-id',
         premium: true,
-        capAmount: BigDecimal.new('100.00')
+        capAmount: BigDecimal('100.00')
       }
       prop2 = Rentlinx::Property.new(h2)
       prop2.patch

--- a/test/models/test_property_amenity.rb
+++ b/test/models/test_property_amenity.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class PropertyAmenityTest < MiniTest::Test
+class PropertyAmenityTest < Minitest::Test
   include SetupMethods
 
   def test_new

--- a/test/models/test_property_link.rb
+++ b/test/models/test_property_link.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class PropertyLinkTest < MiniTest::Test
+class PropertyLinkTest < Minitest::Test
   include SetupMethods
 
   def test_new

--- a/test/models/test_property_photo.rb
+++ b/test/models/test_property_photo.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class PropertyPhotoTest < MiniTest::Test
+class PropertyPhotoTest < Minitest::Test
   include SetupMethods
 
   def test_new

--- a/test/models/test_unit.rb
+++ b/test/models/test_unit.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class UnitTest < MiniTest::Test
+class UnitTest < Minitest::Test
   include SetupMethods
 
   def test_new

--- a/test/models/test_unit_amenity.rb
+++ b/test/models/test_unit_amenity.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class UnitAmenityTest < MiniTest::Test
+class UnitAmenityTest < Minitest::Test
   include SetupMethods
 
   def test_new

--- a/test/models/test_unit_link.rb
+++ b/test/models/test_unit_link.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class UnitLinkTest < MiniTest::Test
+class UnitLinkTest < Minitest::Test
   include SetupMethods
 
   def test_new

--- a/test/models/test_unit_photo.rb
+++ b/test/models/test_unit_photo.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class UnitPhotoTest < MiniTest::Test
+class UnitPhotoTest < Minitest::Test
   include SetupMethods
 
   def test_new

--- a/test/modules/test_amenity_client_methods.rb
+++ b/test/modules/test_amenity_client_methods.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class AmenityClientMethodsTest < MiniTest::Test
+class AmenityClientMethodsTest < Minitest::Test
   include SetupMethods
 
   def test_post_amenities_to_property

--- a/test/modules/test_link_client_methods.rb
+++ b/test/modules/test_link_client_methods.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class LinkClientMethodsTest < MiniTest::Test
+class LinkClientMethodsTest < Minitest::Test
   include SetupMethods
 
   def test_post_links_to_property

--- a/test/modules/test_photo_client_methods.rb
+++ b/test/modules/test_photo_client_methods.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class PhotoClientMethodsTest < MiniTest::Test
+class PhotoClientMethodsTest < Minitest::Test
   include SetupMethods
 
   def test_post_photos

--- a/test/rentlinx/test_client.rb
+++ b/test/rentlinx/test_client.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class ClientTest < MiniTest::Test
+class ClientTest < Minitest::Test
   include SetupMethods
 
   def test_initialize

--- a/test/test_rentlinx.rb
+++ b/test/test_rentlinx.rb
@@ -1,6 +1,6 @@
 require_relative 'helper'
 
-class TestRentlinx < MiniTest::Test
+class TestRentlinx < Minitest::Test
   include SetupMethods
 
   def test_client

--- a/test/validators/test_address_validator.rb
+++ b/test/validators/test_address_validator.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class AddressValidatorTest < MiniTest::Test
+class AddressValidatorTest < Minitest::Test
   def test_validate
     v = Rentlinx::AddressValidator.new('st')
     refute v.valid?

--- a/test/validators/test_amount_validator.rb
+++ b/test/validators/test_amount_validator.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class AmountValidatorTest < MiniTest::Test
+class AmountValidatorTest < Minitest::Test
   def test_validate__invalid
     v = Rentlinx::AmountValidator.new(nil)
     refute v.valid?
@@ -16,9 +16,9 @@ class AmountValidatorTest < MiniTest::Test
   end
 
   def test_validate__valid
-    v = Rentlinx::AmountValidator.new(BigDecimal.new('05.2'))
+    v = Rentlinx::AmountValidator.new(BigDecimal('05.2'))
     assert v.valid?
     assert_equal BigDecimal, v.processed_value.class
-    assert_equal '0.52E1', v.processed_value.to_s
+    assert_equal(0.52e1, v.processed_value)
   end
 end

--- a/test/validators/test_attribute_processor_service.rb
+++ b/test/validators/test_attribute_processor_service.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class AttributeProcessorServiceTest < MiniTest::Test
+class AttributeProcessorServiceTest < Minitest::Test
   def test_process_valid_attrs
     attrs = {
       phoneNumber: '+1 805-323-1212',

--- a/test/validators/test_base_validator.rb
+++ b/test/validators/test_base_validator.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class BaseValidatorTest < MiniTest::Test
+class BaseValidatorTest < Minitest::Test
   def test_can_not_create_instance
     assert_raises(NameError) do
       Rentlinx::BaseValidator.new(1)

--- a/test/validators/test_city_validator.rb
+++ b/test/validators/test_city_validator.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class CityValidatorTest < MiniTest::Test
+class CityValidatorTest < Minitest::Test
   def test_validate
     v = Rentlinx::CityValidator.new('LA')
     refute v.valid?

--- a/test/validators/test_phone_validator.rb
+++ b/test/validators/test_phone_validator.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class PhoneValidatorTest < MiniTest::Test
+class PhoneValidatorTest < Minitest::Test
   def test_valid_phone_numbers
     valid_numbers = [
       '+1-805-555-5555',

--- a/test/validators/test_state_validator.rb
+++ b/test/validators/test_state_validator.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class StateValidatorTest < MiniTest::Test
+class StateValidatorTest < Minitest::Test
   def test_validate
     v = Rentlinx::StateValidator.new('California')
     refute v.valid?

--- a/test/validators/test_url_validator.rb
+++ b/test/validators/test_url_validator.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class UrlValidatorTest < MiniTest::Test
+class UrlValidatorTest < Minitest::Test
   def test_validate
     v = Rentlinx::UrlValidator.new('wrong')
     refute v.valid?

--- a/test/validators/test_zip_validator.rb
+++ b/test/validators/test_zip_validator.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-class ZipValidatorTest < MiniTest::Test
+class ZipValidatorTest < Minitest::Test
   def test_validate
     v = Rentlinx::ZipValidator.new('475888')
     refute v.valid?


### PR DESCRIPTION
This gem has a too-strict `json` gem requirement that is infecting the host system and preventing it from using newer versions of json. In the process of updating it we try to get the test suite to pass on Ruby 3.